### PR TITLE
feat: [FEAT-021] 쿠폰 조회 기능

### DIFF
--- a/src/main/java/com/chs/cafeapp/coupon/controller/CouponController.java
+++ b/src/main/java/com/chs/cafeapp/coupon/controller/CouponController.java
@@ -1,0 +1,37 @@
+package com.chs.cafeapp.coupon.controller;
+
+import com.chs.cafeapp.coupon.dto.CouponResponse;
+import com.chs.cafeapp.coupon.service.CouponService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 쿠폰 Controller
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/coupons")
+public class CouponController {
+  private final CouponService couponService;
+
+  @GetMapping()
+  public ResponseEntity<List<CouponResponse>> viewAllCoupons(@RequestParam String userId) {
+    return ResponseEntity.ok(couponService.viewAllCoupons(userId));
+  }
+
+  @GetMapping("/usable")
+  public ResponseEntity<List<CouponResponse>> viewAllCanUseCoupons(@RequestParam String userId) {
+    return ResponseEntity.ok(couponService.viewAllCanUseCoupons(userId));
+  }
+
+  @GetMapping("/un-usable")
+  public ResponseEntity<List<CouponResponse>> viewAllCanNotUseCoupons(@RequestParam String userId) {
+    return ResponseEntity.ok(couponService.viewAllCanNotUseCoupons(userId));
+  }
+}

--- a/src/main/java/com/chs/cafeapp/coupon/controller/CouponController.java
+++ b/src/main/java/com/chs/cafeapp/coupon/controller/CouponController.java
@@ -20,16 +20,34 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController {
   private final CouponService couponService;
 
+  /**
+   * 쿠폰 전체 조회 Controller
+   * @param userId: 쿠폰 조회할 사용자의 id
+   * @return List<CouponResponse>: 사용자가 가지고 있는 모든 쿠폰 List 반환
+   *                                기존 CouponDto에서 사용 가능, 사용 완료, 기간 만료 등의 statusName 추가
+   */
   @GetMapping()
   public ResponseEntity<List<CouponResponse>> viewAllCoupons(@RequestParam String userId) {
     return ResponseEntity.ok(couponService.viewAllCoupons(userId));
   }
 
+  /**
+   * 사용 가능한 쿠폰 전체 조회 Controller
+   * @param userId: 쿠폰 조회할 사용자의 id
+   * @return List<CouponResponse>: 사용자가 가지고 있는 모든 쿠폰 중 사용 가능한 쿠폰 List 반환
+   *                                기존 CouponDto에서 사용 가능, 사용 완료, 기간 만료 등의 statusName 추가
+   */
   @GetMapping("/usable")
   public ResponseEntity<List<CouponResponse>> viewAllCanUseCoupons(@RequestParam String userId) {
     return ResponseEntity.ok(couponService.viewAllCanUseCoupons(userId));
   }
 
+  /**
+   * 사용 불가능한 쿠폰 전체 조회 Controller
+   * @param userId: 쿠폰 조회할 사용자의 id
+   * @return List<CouponResponse>: 사용자가 가지고 있는 모든 쿠폰 중 사용 불가능한 쿠폰 List 반환
+   *                                기존 CouponDto에서 사용 가능, 사용 완료, 기간 만료 등의 statusName 추가
+   */
   @GetMapping("/un-usable")
   public ResponseEntity<List<CouponResponse>> viewAllCanNotUseCoupons(@RequestParam String userId) {
     return ResponseEntity.ok(couponService.viewAllCanNotUseCoupons(userId));

--- a/src/main/java/com/chs/cafeapp/coupon/dto/CouponDto.java
+++ b/src/main/java/com/chs/cafeapp/coupon/dto/CouponDto.java
@@ -2,12 +2,16 @@ package com.chs.cafeapp.coupon.dto;
 
 import com.chs.cafeapp.coupon.entity.Coupon;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class CouponDto {
   private long id;
@@ -18,6 +22,16 @@ public class CouponDto {
   private LocalDateTime expirationDateTime;
   private boolean expiredYn;
 
+  public static List<CouponDto> of(List<Coupon> couponList) {
+    if (couponList != null) {
+      List<CouponDto> couponDtoList = new ArrayList<>();
+      for (Coupon coupon : couponList) {
+        couponDtoList.add(CouponDto.of(coupon));
+      }
+      return couponDtoList;
+    }
+    return new ArrayList<>();
+  }
   public static CouponDto of(Coupon coupon) {
     return CouponDto.builder()
         .id(coupon.getId())

--- a/src/main/java/com/chs/cafeapp/coupon/dto/CouponResponse.java
+++ b/src/main/java/com/chs/cafeapp/coupon/dto/CouponResponse.java
@@ -1,0 +1,89 @@
+package com.chs.cafeapp.coupon.dto;
+
+import static com.chs.cafeapp.coupon.type.CouponStatus.ALREADY_USED_COUPON;
+import static com.chs.cafeapp.coupon.type.CouponStatus.CAN_USE_COUPON;
+import static com.chs.cafeapp.coupon.type.CouponStatus.EXPIRED_COUPON;
+
+import com.chs.cafeapp.coupon.type.CouponStatus;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CouponResponse {
+
+  private long id;
+  private String userId;
+  private String couponName;
+  private int price;
+  private boolean usedYn;
+  private LocalDateTime expirationDateTime;
+  private boolean expiredYn;
+  private String couponStatus;
+
+  public void setCouponStatus(String couponStatus) {
+    this.couponStatus = couponStatus;
+  }
+
+  public static List<CouponResponse> toResponse(List<CouponDto> couponDtoList) {
+
+    if (couponDtoList != null) {
+      List<CouponResponse> couponResponseList = new ArrayList<>();
+      for (CouponDto couponDto : couponDtoList) {
+        CouponResponse couponResponse = CouponResponse.toResponse(couponDto);
+        if (!couponResponse.usedYn && !couponResponse.expiredYn) {
+          couponResponse.setCouponStatus(CAN_USE_COUPON.getStatusName());
+        }
+        if (couponResponse.usedYn) {
+          couponResponse.setCouponStatus(ALREADY_USED_COUPON.getStatusName());
+        }
+        if (couponResponse.expiredYn) {
+          couponResponse.setCouponStatus(EXPIRED_COUPON.getStatusName());
+        }
+        couponResponseList.add(couponResponse);
+      }
+      return couponResponseList;
+    }
+    return new ArrayList<>();
+  }
+  public static CouponResponse toResponse(CouponDto couponDto) {
+    return CouponResponse.builder()
+        .id(couponDto.getId())
+        .userId(couponDto.getUserId())
+        .couponName(couponDto.getCouponName())
+        .price(couponDto.getPrice())
+        .usedYn(couponDto.isUsedYn())
+        .expirationDateTime(couponDto.getExpirationDateTime())
+        .expiredYn(couponDto.isExpiredYn())
+        .build();
+  }
+
+  public static List<CouponResponse> toResponse(List<CouponDto> couponDtoList, String couponStatus) {
+
+    if (couponDtoList != null) {
+      List<CouponResponse> couponResponseList = new ArrayList<>();
+      for (CouponDto couponDto : couponDtoList) {
+        couponResponseList.add(CouponResponse.toResponse(couponDto, couponStatus));
+      }
+      return couponResponseList;
+    }
+    return new ArrayList<>();
+  }
+  public static CouponResponse toResponse(CouponDto couponDto, String couponStatus) {
+    return CouponResponse.builder()
+        .id(couponDto.getId())
+        .userId(couponDto.getUserId())
+        .couponName(couponDto.getCouponName())
+        .price(couponDto.getPrice())
+        .usedYn(couponDto.isUsedYn())
+        .expirationDateTime(couponDto.getExpirationDateTime())
+        .expiredYn(couponDto.isExpiredYn())
+        .couponStatus(couponStatus)
+        .build();
+  }
+}

--- a/src/main/java/com/chs/cafeapp/coupon/dto/CouponResponse.java
+++ b/src/main/java/com/chs/cafeapp/coupon/dto/CouponResponse.java
@@ -4,7 +4,6 @@ import static com.chs.cafeapp.coupon.type.CouponStatus.ALREADY_USED_COUPON;
 import static com.chs.cafeapp.coupon.type.CouponStatus.CAN_USE_COUPON;
 import static com.chs.cafeapp.coupon.type.CouponStatus.EXPIRED_COUPON;
 
-import com.chs.cafeapp.coupon.type.CouponStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,11 +38,11 @@ public class CouponResponse {
         if (!couponResponse.usedYn && !couponResponse.expiredYn) {
           couponResponse.setCouponStatus(CAN_USE_COUPON.getStatusName());
         }
-        if (couponResponse.usedYn) {
-          couponResponse.setCouponStatus(ALREADY_USED_COUPON.getStatusName());
-        }
         if (couponResponse.expiredYn) {
           couponResponse.setCouponStatus(EXPIRED_COUPON.getStatusName());
+        }
+        if (couponResponse.usedYn) {
+          couponResponse.setCouponStatus(ALREADY_USED_COUPON.getStatusName());
         }
         couponResponseList.add(couponResponse);
       }

--- a/src/main/java/com/chs/cafeapp/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/chs/cafeapp/coupon/repository/CouponRepository.java
@@ -1,8 +1,14 @@
 package com.chs.cafeapp.coupon.repository;
 
 import com.chs.cafeapp.coupon.entity.Coupon;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
+  List<Coupon> findAllByUserId(Long userId);
+
+  List<Coupon> findAllByUserIdAndUsedYnFalseAndExpiredYnFalse(Long userId);
+
+  List<Coupon> findAllByUserIdAndUsedYnTrueOrUserIdAndExpiredYnTrue(Long userId1, Long userId2);
 }

--- a/src/main/java/com/chs/cafeapp/coupon/service/CouponService.java
+++ b/src/main/java/com/chs/cafeapp/coupon/service/CouponService.java
@@ -1,6 +1,8 @@
 package com.chs.cafeapp.coupon.service;
 
 import com.chs.cafeapp.coupon.dto.CouponDto;
+import com.chs.cafeapp.coupon.dto.CouponResponse;
+import java.util.List;
 
 public interface CouponService {
 
@@ -8,4 +10,17 @@ public interface CouponService {
    * 쿠폰 생성
    */
   CouponDto createCouponByStamp(String userId);
+
+  /**
+   * 쿠폰 전체 조회
+   */
+  List<CouponResponse> viewAllCoupons(String userId);
+  /**
+   * 사용할 수 있는 쿠폰만 조회
+   */
+  List<CouponResponse> viewAllCanUseCoupons(String userId);
+  /**
+   * 사용할 수 없는 쿠폰 전체 조회
+   */
+  List<CouponResponse> viewAllCanNotUseCoupons(String userId);
 }

--- a/src/main/java/com/chs/cafeapp/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/chs/cafeapp/coupon/service/impl/CouponServiceImpl.java
@@ -64,10 +64,11 @@ public class CouponServiceImpl implements CouponService {
         .expiredYn(false)
         .build();
 
-    user.setCoupons(couponByStamp);
+    Coupon saveCoupon = couponRepository.save(couponByStamp);
+    user.setCoupons(saveCoupon);
     userRepository.save(user);
 
-    return CouponDto.of(couponRepository.save(couponByStamp));
+    return CouponDto.of(saveCoupon);
   }
 
   @Override

--- a/src/main/java/com/chs/cafeapp/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/com/chs/cafeapp/coupon/service/impl/CouponServiceImpl.java
@@ -1,10 +1,12 @@
 package com.chs.cafeapp.coupon.service.impl;
 
+import static com.chs.cafeapp.coupon.type.CouponStatus.CAN_USE_COUPON;
 import static com.chs.cafeapp.exception.type.ErrorCode.COUPON_NOT_FOUND;
 import static com.chs.cafeapp.exception.type.ErrorCode.NOT_MATCH_USER_AND_COUPON;
 import static com.chs.cafeapp.exception.type.ErrorCode.USER_NOT_FOUND;
 
 import com.chs.cafeapp.coupon.dto.CouponDto;
+import com.chs.cafeapp.coupon.dto.CouponResponse;
 import com.chs.cafeapp.coupon.entity.Coupon;
 import com.chs.cafeapp.coupon.repository.CouponRepository;
 import com.chs.cafeapp.coupon.service.CouponService;
@@ -12,6 +14,7 @@ import com.chs.cafeapp.exception.CustomException;
 import com.chs.cafeapp.user.entity.User;
 import com.chs.cafeapp.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,6 +26,13 @@ public class CouponServiceImpl implements CouponService {
 
   private final String COUPON_NAME_BY_STAMP = "스탬프 10회 적립 아메리카노 교환 쿠폰";
   private final int COUPON_PRICE_BY_STAMP = 4100;
+
+  public User validationUser(String userId) {
+    User user = userRepository.findByLoginId(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    return user;
+  }
   public Coupon validationUserAndCoupon(String userId, long couponId) {
     User user = userRepository.findByLoginId(userId)
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -58,5 +68,26 @@ public class CouponServiceImpl implements CouponService {
     userRepository.save(user);
 
     return CouponDto.of(couponRepository.save(couponByStamp));
+  }
+
+  @Override
+  public List<CouponResponse> viewAllCoupons(String userId) {
+    User user = validationUser(userId);
+    List<Coupon> coupons = couponRepository.findAllByUserId(user.getId());
+    return CouponResponse.toResponse(CouponDto.of(coupons));
+  }
+
+  @Override
+  public List<CouponResponse> viewAllCanUseCoupons(String userId) {
+    User user = validationUser(userId);
+    List<Coupon> coupons = couponRepository.findAllByUserIdAndUsedYnFalseAndExpiredYnFalse(user.getId());
+    return CouponResponse.toResponse(CouponDto.of(coupons), CAN_USE_COUPON.getStatusName());
+  }
+
+  @Override
+  public List<CouponResponse> viewAllCanNotUseCoupons(String userId) {
+    User user = validationUser(userId);
+    List<Coupon> coupons = couponRepository.findAllByUserIdAndUsedYnTrueOrUserIdAndExpiredYnTrue(user.getId(), user.getId());
+    return CouponResponse.toResponse(CouponDto.of(coupons));
   }
 }

--- a/src/main/java/com/chs/cafeapp/coupon/type/CouponStatus.java
+++ b/src/main/java/com/chs/cafeapp/coupon/type/CouponStatus.java
@@ -1,0 +1,23 @@
+package com.chs.cafeapp.coupon.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CouponStatus {
+  /**
+   * 사용 가능
+   */
+  CAN_USE_COUPON("사용 가능"),
+  /**
+   * 기간 만료(사용 불가)
+   */
+  EXPIRED_COUPON("기간 만료"),
+  /**
+   * 사용 완료(사용 불가)
+   */
+  ALREADY_USED_COUPON("사용 완료");
+
+  private final String statusName;
+}

--- a/src/main/java/com/chs/cafeapp/menu/controller/MenuAdminController.java
+++ b/src/main/java/com/chs/cafeapp/menu/controller/MenuAdminController.java
@@ -7,6 +7,7 @@ import com.chs.cafeapp.menu.dto.MenuInput;
 import com.chs.cafeapp.menu.dto.MenuResponse;
 import com.chs.cafeapp.menu.service.MenuService;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,11 +26,11 @@ import com.chs.cafeapp.exception.CustomException;
  * 메뉴 CRUD Controller
  */
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/admin/menus")
 public class MenuAdminController {
 
-  @Autowired
-  private MenuService menuService;
+  private final MenuService menuService;
 
   /**
    * 메뉴 생성 Controller

--- a/src/main/java/com/chs/cafeapp/security/SecurityConfig.java
+++ b/src/main/java/com/chs/cafeapp/security/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
-            .antMatchers("/admin/**", "/", "/orders/**", "/carts/**" ).permitAll();
+            .antMatchers("/admin/**", "/", "/orders/**", "/carts/**" ,"/coupons/**").permitAll();
 
         http
             .httpBasic().disable()

--- a/src/test/java/com/chs/cafeapp/entity/CouponRepositoryTest.java
+++ b/src/test/java/com/chs/cafeapp/entity/CouponRepositoryTest.java
@@ -1,0 +1,130 @@
+package com.chs.cafeapp.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.chs.cafeapp.coupon.entity.Coupon;
+import com.chs.cafeapp.coupon.repository.CouponRepository;
+import com.chs.cafeapp.user.entity.User;
+import com.chs.cafeapp.user.repository.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CouponRepositoryTest {
+  static User user;
+  static Coupon coupon1;
+  static Coupon coupon2;
+  static Coupon coupon3;
+  static Coupon coupon4;
+  static Coupon coupon5;
+  @Autowired
+  private EntityManager em;
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private CouponRepository couponRepository;
+
+  @BeforeEach
+  public void setCouponAndUser() {
+    coupon1 = Coupon.builder()
+        .id(1L)
+        .usedYn(false)
+        .expiredYn(false)
+        .build();
+
+    coupon2 = Coupon.builder()
+        .id(2L)
+        .usedYn(false)
+        .expiredYn(false)
+        .build();
+
+    coupon3 = Coupon.builder()
+        .id(3L)
+        .usedYn(true)
+        .expiredYn(false)
+        .build();
+
+    coupon4 = Coupon.builder()
+        .id(4L)
+        .usedYn(true)
+        .expiredYn(true)
+        .build();
+
+    coupon5 = Coupon.builder()
+        .id(5L)
+        .usedYn(false)
+        .expiredYn(true)
+        .build();
+
+    em.merge(coupon1);
+    em.merge(coupon2);
+    em.merge(coupon3);
+    em.merge(coupon4);
+    em.merge(coupon5);
+
+    user = User.builder()
+        .id(1L)
+        .loginId("user2@naver.com")
+        .coupons(Arrays.asList(coupon1, coupon2, coupon3, coupon4, coupon5))
+        .build();
+
+    em.merge(user);
+
+    coupon1.setUser(user);
+    coupon2.setUser(user);
+    coupon3.setUser(user);
+    coupon4.setUser(user);
+    coupon5.setUser(user);
+
+    em.merge(coupon1);
+    em.merge(coupon2);
+    em.merge(coupon3);
+    em.merge(coupon4);
+    em.merge(coupon5);
+  }
+
+  @Test
+  @DisplayName("쿠폰 전체 조회")
+  void findAllByUserId() {
+
+    // when
+    List<Coupon> coupons = couponRepository.findAllByUserId(1L);
+    // then
+    assertNotNull(coupons);
+    assertEquals(coupons.size(), 5);
+  }
+
+  @Test
+  @DisplayName("사용 가능한 쿠폰 전체 조회")
+  void findAllByUserIdAndUsedYnFalseAndExpiredYnFalse() {
+    // when
+    List<Coupon> coupons = couponRepository.findAllByUserIdAndUsedYnFalseAndExpiredYnFalse(1L);
+    // then
+    assertNotNull(coupons);
+    assertEquals(coupons.size(), 2);
+  }
+
+  @Test
+  @DisplayName("사용 불가능한 쿠폰 전체 조회")
+  void findAllByUserIdAndUsedYnTrueOrUserIdAndExpiredYnTrue() {
+    // when
+    List<Coupon> coupons = couponRepository.findAllByUserIdAndUsedYnTrueOrUserIdAndExpiredYnTrue(1L, 1L);
+    // then
+    assertNotNull(coupons);
+    assertEquals(coupons.size(), 3);
+  }
+}

--- a/src/test/java/com/chs/cafeapp/service/coupon/CouponServiceImplTest.java
+++ b/src/test/java/com/chs/cafeapp/service/coupon/CouponServiceImplTest.java
@@ -1,5 +1,8 @@
 package com.chs.cafeapp.service.coupon;
 
+import static com.chs.cafeapp.coupon.type.CouponStatus.ALREADY_USED_COUPON;
+import static com.chs.cafeapp.coupon.type.CouponStatus.CAN_USE_COUPON;
+import static com.chs.cafeapp.coupon.type.CouponStatus.EXPIRED_COUPON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.chs.cafeapp.coupon.dto.CouponDto;
+import com.chs.cafeapp.coupon.dto.CouponResponse;
 import com.chs.cafeapp.coupon.entity.Coupon;
 import com.chs.cafeapp.coupon.repository.CouponRepository;
 import com.chs.cafeapp.coupon.service.impl.CouponServiceImpl;
@@ -15,7 +19,10 @@ import com.chs.cafeapp.stamp.entity.Stamp;
 import com.chs.cafeapp.user.entity.User;
 import com.chs.cafeapp.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +32,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CouponServiceImplTest {
-
+  static User user;
+  static Coupon coupon1;
+  static Coupon coupon2;
+  static Coupon coupon3;
+  static Coupon coupon4;
+  static Coupon coupon5;
   @Mock
   private UserRepository userRepository;
 
@@ -35,37 +47,139 @@ class CouponServiceImplTest {
   @InjectMocks
   private CouponServiceImpl couponService;
 
+  @BeforeEach
+  public void setCouponAndUser() {
+    coupon1 = Coupon.builder()
+        .id(1L)
+        .usedYn(false)
+        .expiredYn(false)
+        .build();
+
+    coupon2 = Coupon.builder()
+        .id(2L)
+        .usedYn(false)
+        .expiredYn(false)
+        .build();
+
+    coupon3 = Coupon.builder()
+        .id(3L)
+        .usedYn(true)
+        .expiredYn(false)
+        .build();
+
+    coupon4 = Coupon.builder()
+        .id(4L)
+        .usedYn(true)
+        .expiredYn(true)
+        .build();
+
+    coupon5 = Coupon.builder()
+        .id(5L)
+        .usedYn(false)
+        .expiredYn(true)
+        .build();
+
+    user = User.builder()
+        .id(1L)
+        .loginId("user2@naver.com")
+        .coupons(Arrays.asList(coupon1, coupon2, coupon3, coupon4, coupon5))
+        .build();
+
+    coupon1.setUser(user);
+    coupon2.setUser(user);
+    coupon3.setUser(user);
+    coupon4.setUser(user);
+    coupon5.setUser(user);
+
+    userRepository.save(user);
+
+    couponRepository.save(coupon1);
+    couponRepository.save(coupon2);
+    couponRepository.save(coupon3);
+    couponRepository.save(coupon4);
+    couponRepository.save(coupon5);
+  }
+
   @Test
   @DisplayName("스탬프 10회 적립시 쿠폰 자동 생성 성공")
   void createCouponByStamp_Success() {
     // given
-    User user = User.builder()
-        .id(1L)
-        .loginId("user2@naver.com")
+    User user3 = User.builder()
+        .id(3L)
+        .loginId("user3@naver.com")
         .build();
 
     Stamp stamp = Stamp.builder()
         .id(1L)
         .stampNumbers(8)
-        .user(user)
+        .user(user3)
         .build();
 
     LocalDateTime expirationDateTime = LocalDateTime.now().plusMonths(2);
     Coupon coupon = Coupon.builder()
-        .id(1L)
-        .user(user)
+        .id(100L)
+        .user(user3)
         .price(4100)
         .expirationDateTime(expirationDateTime)
         .build();
 
-    when(userRepository.findByLoginId(anyString())).thenReturn(Optional.of(user));
+    when(userRepository.findByLoginId(anyString())).thenReturn(Optional.of(user3));
     when(couponRepository.save(any(Coupon.class))).thenReturn(coupon);
     // when
-    CouponDto couponDtoByStamp = couponService.createCouponByStamp("user2@naver.com");
+    CouponDto couponDtoByStamp = couponService.createCouponByStamp("user3@naver.com");
 
     // then
     assertNotNull(couponDtoByStamp);
     assertTrue(couponDtoByStamp.getExpirationDateTime().equals(expirationDateTime));
     assertEquals(couponDtoByStamp.getPrice(), 4100);
+  }
+  @Test
+  @DisplayName("쿠폰 전체 조회")
+  void viewAllCouponsTest() {
+      //given
+
+      //when
+    when(userRepository.findByLoginId(anyString())).thenReturn(Optional.of(user));
+    when(couponRepository.findAllByUserId(1L)).thenReturn(Arrays.asList(coupon1, coupon2, coupon3, coupon4, coupon5));
+    List<CouponResponse> couponResponseList = couponService.viewAllCoupons("user2@naver.com");
+
+    //then
+    assertNotNull(couponResponseList);
+    assertEquals(couponResponseList.size(), 5);
+  }
+
+  @Test
+  @DisplayName("사용 가능한 쿠폰 전체 조회")
+  void viewAllCanUseCouponsTest() {
+      //given
+
+    //when
+    when(userRepository.findByLoginId(anyString())).thenReturn(Optional.of(user));
+    when(couponRepository.findAllByUserIdAndUsedYnFalseAndExpiredYnFalse(1L)).thenReturn(Arrays.asList(coupon1, coupon2));
+    List<CouponResponse> couponResponseList = couponService.viewAllCanUseCoupons("user2@naver.com");
+
+    //then
+    assertNotNull(couponResponseList);
+    assertEquals(couponResponseList.size(), 2);
+    assertEquals(couponResponseList.get(0).getCouponStatus(), CAN_USE_COUPON.getStatusName());
+    assertEquals(couponResponseList.get(1).getCouponStatus(), CAN_USE_COUPON.getStatusName());
+  }
+
+  @Test
+  @DisplayName("사용 불가능한 쿠폰 전체 조회")
+  void viewAllCanNotUsedCouponsTest() {
+    //given
+
+    //when
+    when(userRepository.findByLoginId(anyString())).thenReturn(Optional.of(user));
+    when(couponRepository.findAllByUserIdAndUsedYnTrueOrUserIdAndExpiredYnTrue(1L, 1L)).thenReturn(Arrays.asList(coupon3, coupon4, coupon5));
+    List<CouponResponse> couponResponseList = couponService.viewAllCanNotUseCoupons("user2@naver.com");
+
+    //then
+    assertNotNull(couponResponseList);
+    assertEquals(couponResponseList.size(), 3);
+    assertEquals(couponResponseList.get(0).getCouponStatus(), ALREADY_USED_COUPON.getStatusName());
+    assertEquals(couponResponseList.get(1).getCouponStatus(), ALREADY_USED_COUPON.getStatusName());
+    assertEquals(couponResponseList.get(2).getCouponStatus(), EXPIRED_COUPON.getStatusName());
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
💿 MenuAdminController에 MenuService를 AutoWired 어노테이션으로 주입

**TO-BE**
📀  MenuAdminController에 MenuServic를 RequiredArgsConstructor 어노테이션, private final로 주입
📀 1. 쿠폰 전체 조회
📀2. 사용 가능한 쿠폰 전체 조회
📀3. 사용 불가능한 쿠폰 전체 조회(사용 완료, 기간 만료 동시에 확인)

*TO-DO*
쿠폰 조회시, 해당 JPA 사용이 올바른지, 더 좋은 쿼리문 혹은 방법이 있는지 나중에 refactoring할 수 있으면 해야함.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 
