### PR TITLE
feat: [FEAT-026] 스케줄을 이용해 주문, 쿠폰, 사용자 정기적으로 삭제 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
 	implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.3'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'com.h2database:h2'
 
 	implementation 'com.querydsl:querydsl-jpa'
 	annotationProcessor 'com.querydsl:querydsl-apt'

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,19 @@ dependencies {
 
 }
 
-tasks.named('test') {
+sourceSets {
+	test {
+		resources {
+			srcDir 'src/test/resources'
+		}
+	}
+}
+
+//tasks.named('test') {
+//	useJUnitPlatform()
+//}
+
+test {
 	useJUnitPlatform()
+	systemProperty "spring.profiles.active", "test"
 }

--- a/src/main/java/com/chs/cafeapp/CafeAppApplication.java
+++ b/src/main/java/com/chs/cafeapp/CafeAppApplication.java
@@ -3,7 +3,10 @@ package com.chs.cafeapp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class CafeAppApplication {

--- a/src/main/java/com/chs/cafeapp/config/scheduling/SchedulingConfig.java
+++ b/src/main/java/com/chs/cafeapp/config/scheduling/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.chs.cafeapp.config.scheduling;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/src/main/java/com/chs/cafeapp/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/chs/cafeapp/coupon/repository/CouponRepository.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
   List<Coupon> findAllByUserId(Long userId);
+  List<Coupon> findAllByUpdateDateTimeLessThan(LocalDateTime localDateTime);
   List<Coupon> findAllByUserIdAndUsedYnFalseAndExpiredYnFalse(Long userId);
   List<Coupon> findAllByUserIdAndUsedYnTrueOrUserIdAndExpiredYnTrue(Long userId1, Long userId2);
 

--- a/src/main/java/com/chs/cafeapp/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/chs/cafeapp/coupon/repository/CouponRepository.java
@@ -1,10 +1,12 @@
 package com.chs.cafeapp.coupon.repository;
 
 import com.chs.cafeapp.coupon.entity.Coupon;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
@@ -16,4 +18,6 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
   Page<Coupon> findAllByUserIdAndUsedYnFalseAndExpiredYnFalse(Long userId, Pageable pageable);
   Page<Coupon> findAllByUserIdAndUsedYnTrueOrUserIdAndExpiredYnTrue(Long userId1, Long userId2, Pageable pageable);
 
+  @Transactional
+  void deleteAllByUpdateDateTimeLessThan(LocalDateTime nowLocalDateTime);
 }

--- a/src/main/java/com/chs/cafeapp/order/controller/OrderAdminController.java
+++ b/src/main/java/com/chs/cafeapp/order/controller/OrderAdminController.java
@@ -3,7 +3,7 @@ package com.chs.cafeapp.order.controller;
 import com.chs.cafeapp.kafka.service.KafkaProducerService;
 import com.chs.cafeapp.order.dto.OrderDto;
 import com.chs.cafeapp.order.dto.OrderResponse;
-import com.chs.cafeapp.order.service.OrderServiceForAdmin;
+import com.chs.cafeapp.order.service.OrderAdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/admin/orders")
 public class OrderAdminController {
-  private final OrderServiceForAdmin orderServiceForAdmin;
+  private final OrderAdminService orderAdminService;
   private final KafkaProducerService producerService;
 
   /**
@@ -32,7 +32,7 @@ public class OrderAdminController {
    */
   @GetMapping()
   public ResponseEntity<Slice<OrderDto>> viewAllOrders(Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewAllOrders(pageable));
+    return ResponseEntity.ok(orderAdminService.viewAllOrders(pageable));
   }
 
   /**
@@ -43,7 +43,7 @@ public class OrderAdminController {
    */
   @GetMapping("/days")
   public ResponseEntity<Slice<OrderDto>> viewOrdersDuringDays(Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewAllOrdersDuringDays(pageable));
+    return ResponseEntity.ok(orderAdminService.viewAllOrdersDuringDays(pageable));
   }
 
   /**
@@ -54,7 +54,7 @@ public class OrderAdminController {
    */
   @GetMapping("/weeks")
   public ResponseEntity<Slice<OrderDto>> viewOrdersDuringWeeks(Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewAllOrdersDuringWeeks(pageable));
+    return ResponseEntity.ok(orderAdminService.viewAllOrdersDuringWeeks(pageable));
   }
 
   /**
@@ -65,7 +65,7 @@ public class OrderAdminController {
    */
   @GetMapping("/months")
   public ResponseEntity<Slice<OrderDto>> viewOrdersDuringMonths(Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewAllOrdersDuringMonths(pageable));
+    return ResponseEntity.ok(orderAdminService.viewAllOrdersDuringMonths(pageable));
   }
 
   /**
@@ -76,7 +76,7 @@ public class OrderAdminController {
    */
   @GetMapping("/three-months")
   public ResponseEntity<Slice<OrderDto>> viewOrdersDuringThreeMonths(Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewAllOrdersDuringThreeMonths(pageable));
+    return ResponseEntity.ok(orderAdminService.viewAllOrdersDuringThreeMonths(pageable));
   }
 
   /**
@@ -87,7 +87,7 @@ public class OrderAdminController {
    */
   @GetMapping("/six-months")
   public ResponseEntity<Slice<OrderDto>> viewOrdersDuringSixMonths(Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewAllOrdersDuringSixMonths(pageable));
+    return ResponseEntity.ok(orderAdminService.viewAllOrdersDuringSixMonths(pageable));
   }
 
   /**
@@ -98,7 +98,7 @@ public class OrderAdminController {
    */
   @GetMapping("/years")
   public ResponseEntity<Slice<OrderDto>> viewOrdersDuringYears(Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewAllOrdersDuringYears(pageable));
+    return ResponseEntity.ok(orderAdminService.viewAllOrdersDuringYears(pageable));
   }
 
   /**
@@ -110,7 +110,7 @@ public class OrderAdminController {
    */
   @GetMapping("/order-status/{orderStatusNum}")
   public ResponseEntity<Slice<OrderDto>> viewOrdersByOrderStatus(@PathVariable int orderStatusNum, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewOrdersByOrderStatus(orderStatusNum, pageable));
+    return ResponseEntity.ok(orderAdminService.viewOrdersByOrderStatus(orderStatusNum, pageable));
   }
 
   /**
@@ -122,7 +122,8 @@ public class OrderAdminController {
    */
   @GetMapping("/order-status/{orderStatusNum}/days")
   public ResponseEntity<Slice<OrderDto>> viewOrdersByOrderStatusDuringDays(@PathVariable int orderStatusNum, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewOrdersByOrderStatusDuringDays(orderStatusNum, pageable));
+    return ResponseEntity.ok(
+        orderAdminService.viewOrdersByOrderStatusDuringDays(orderStatusNum, pageable));
   }
 
   /**
@@ -134,7 +135,8 @@ public class OrderAdminController {
    */
   @GetMapping("/order-status/{orderStatusNum}/weeks")
   public ResponseEntity<Slice<OrderDto>> viewOrdersByOrderStatusDuringWeeks(@PathVariable int orderStatusNum, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewOrdersByOrderStatusDuringWeeks(orderStatusNum, pageable));
+    return ResponseEntity.ok(
+        orderAdminService.viewOrdersByOrderStatusDuringWeeks(orderStatusNum, pageable));
   }
 
   /**
@@ -146,7 +148,8 @@ public class OrderAdminController {
    */
   @GetMapping("/order-status/{orderStatusNum}/months")
   public ResponseEntity<Slice<OrderDto>> viewOrdersByOrderStatusDuringMonths(@PathVariable int orderStatusNum, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewOrdersByOrderStatusDuringMonths(orderStatusNum, pageable));
+    return ResponseEntity.ok(
+        orderAdminService.viewOrdersByOrderStatusDuringMonths(orderStatusNum, pageable));
   }
 
   /**
@@ -158,7 +161,8 @@ public class OrderAdminController {
    */
   @GetMapping("/order-status/{orderStatusNum}/three-months")
   public ResponseEntity<Slice<OrderDto>> viewOrdersByOrderStatusDuringThreeMonths(@PathVariable int orderStatusNum, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewOrdersByOrderStatusDuringThreeMonths(orderStatusNum, pageable));
+    return ResponseEntity.ok(
+        orderAdminService.viewOrdersByOrderStatusDuringThreeMonths(orderStatusNum, pageable));
   }
 
   /**
@@ -170,7 +174,8 @@ public class OrderAdminController {
    */
   @GetMapping("/order-status/{orderStatusNum}/six-months")
   public ResponseEntity<Slice<OrderDto>> viewOrdersByOrderStatusDuringSixMonths(@PathVariable int orderStatusNum, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewOrdersByOrderStatusDuringSixMonths(orderStatusNum, pageable));
+    return ResponseEntity.ok(
+        orderAdminService.viewOrdersByOrderStatusDuringSixMonths(orderStatusNum, pageable));
   }
 
   /**
@@ -182,7 +187,8 @@ public class OrderAdminController {
    */
   @GetMapping("/order-status/{orderStatusNum}/years")
   public ResponseEntity<Slice<OrderDto>> viewOrdersByOrderStatusDuringYears(@PathVariable int orderStatusNum, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForAdmin.viewOrdersByOrderStatusDuringYears(orderStatusNum, pageable));
+    return ResponseEntity.ok(
+        orderAdminService.viewOrdersByOrderStatusDuringYears(orderStatusNum, pageable));
   }
 
   /**
@@ -192,7 +198,7 @@ public class OrderAdminController {
    */
   @PatchMapping("/rejections/{orderId}")
   public ResponseEntity<OrderResponse> rejectOrderStatus(@PathVariable long orderId) {
-    OrderDto orderDto = orderServiceForAdmin.rejectOrder(orderId);
+    OrderDto orderDto = orderAdminService.rejectOrder(orderId);
     return ResponseEntity.ok(OrderResponse.toResponse(orderDto, orderDto.getOrderStatus().getDescription()));
   }
 
@@ -204,8 +210,8 @@ public class OrderAdminController {
   @PatchMapping("/order-status/{orderId}")
   public ResponseEntity<OrderResponse> changeOrderStatus(@PathVariable long orderId) {
 
-    OrderDto orderDto = orderServiceForAdmin.changeOrderStatus(orderId);
-    String message = orderServiceForAdmin.viewMessageChanges(orderId);
+    OrderDto orderDto = orderAdminService.changeOrderStatus(orderId);
+    String message = orderAdminService.viewMessageChanges(orderId);
     OrderResponse response = OrderResponse.toResponse(orderDto, message);
     producerService.sendMessage(orderId, orderDto.getOrderStatus().getStatusName());
     return ResponseEntity.ok(response);

--- a/src/main/java/com/chs/cafeapp/order/controller/OrderController.java
+++ b/src/main/java/com/chs/cafeapp/order/controller/OrderController.java
@@ -7,8 +7,7 @@ import com.chs.cafeapp.order.dto.OrderDto;
 import com.chs.cafeapp.order.dto.OrderFromCartInput;
 import com.chs.cafeapp.order.dto.OrderInput;
 import com.chs.cafeapp.order.dto.OrderResponse;
-import com.chs.cafeapp.order.service.OrderServiceForAdmin;
-import com.chs.cafeapp.order.service.OrderServiceForUser;
+import com.chs.cafeapp.order.service.OrderUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/orders")
 public class OrderController {
-  private final OrderServiceForUser orderServiceForUser;
+  private final OrderUserService orderUserService;
 
 
   /**
@@ -42,7 +41,7 @@ public class OrderController {
    */
   @PostMapping()
   public OrderResponse addOrder(@RequestBody OrderInput request, @RequestParam String userId) {
-    OrderDto orderDto = orderServiceForUser.orderIndividualMenu(request, userId);
+    OrderDto orderDto = orderUserService.orderIndividualMenu(request, userId);
     return OrderResponse.toResponse(orderDto, orderDto.getOrderStatus().getDescription());
   }
 
@@ -59,7 +58,7 @@ public class OrderController {
    */
   @PostMapping("/shopping-basket/select-items/{selectItemCount}")
   public OrderResponse addOrderFromBasket(@PathVariable int selectItemCount, @RequestBody OrderFromCartInput request, @RequestParam String userId) {
-    OrderDto orderDto = orderServiceForUser.orderFromCart(request, userId);
+    OrderDto orderDto = orderUserService.orderFromCart(request, userId);
     return OrderResponse.toResponse(orderDto, orderDto.getOrderStatus().getDescription());
   }
 
@@ -75,7 +74,7 @@ public class OrderController {
    */
   @PostMapping("/shopping-basket")
   public OrderResponse addOrderFromBasket(@RequestBody OrderAllFromCartInput reqeust, @RequestParam String userId) {
-    OrderDto orderDto = orderServiceForUser.orderAllFromCart(reqeust, userId);
+    OrderDto orderDto = orderUserService.orderAllFromCart(reqeust, userId);
     return OrderResponse.toResponse(orderDto, orderDto.getOrderStatus().getDescription());
   }
 
@@ -86,7 +85,7 @@ public class OrderController {
    */
   @PatchMapping("/cancels/{orderId}")
   public ResponseEntity<OrderResponse> rejectOrderStatus(@PathVariable long orderId, @RequestParam String userId) {
-    OrderDto orderDto = orderServiceForUser.cancelOrder(orderId, userId);
+    OrderDto orderDto = orderUserService.cancelOrder(orderId, userId);
     return ResponseEntity.ok(OrderResponse.toResponse(orderDto, orderDto.getOrderStatus().getDescription()));
   }
 
@@ -99,7 +98,7 @@ public class OrderController {
    */
   @GetMapping()
   public ResponseEntity<Slice<OrderDto>> viewOrdersAll(@RequestParam String userId, Pageable pageable) {
-    return ResponseEntity.ok(orderServiceForUser.viewAllOrders(userId, pageable));
+    return ResponseEntity.ok(orderUserService.viewAllOrders(userId, pageable));
   }
 
   /**
@@ -114,7 +113,7 @@ public class OrderController {
       @RequestParam String userId,
       Pageable pageable
   ) {
-    return ResponseEntity.ok(orderServiceForUser.viewAllOrdersDuringDays(userId, pageable));
+    return ResponseEntity.ok(orderUserService.viewAllOrdersDuringDays(userId, pageable));
   }
 
   /**
@@ -129,7 +128,7 @@ public class OrderController {
       @RequestParam String userId,
       Pageable pageable
   ) {
-    return ResponseEntity.ok(orderServiceForUser.viewAllOrdersDuringWeeks(userId, pageable));
+    return ResponseEntity.ok(orderUserService.viewAllOrdersDuringWeeks(userId, pageable));
   }
 
   /**
@@ -144,7 +143,7 @@ public class OrderController {
       @RequestParam String userId,
       Pageable pageable
   ) {
-    return ResponseEntity.ok(orderServiceForUser.viewAllOrdersDuringMonths(userId, pageable));
+    return ResponseEntity.ok(orderUserService.viewAllOrdersDuringMonths(userId, pageable));
   }
 
   /**
@@ -159,7 +158,7 @@ public class OrderController {
       @RequestParam String userId,
       Pageable pageable
   ) {
-    return ResponseEntity.ok(orderServiceForUser.viewAllOrdersDuringThreeMonths(userId, pageable));
+    return ResponseEntity.ok(orderUserService.viewAllOrdersDuringThreeMonths(userId, pageable));
   }
 
   /**
@@ -174,7 +173,7 @@ public class OrderController {
       @RequestParam String userId,
       Pageable pageable
   ) {
-    return ResponseEntity.ok(orderServiceForUser.viewAllOrdersDuringSixMonths(userId, pageable));
+    return ResponseEntity.ok(orderUserService.viewAllOrdersDuringSixMonths(userId, pageable));
   }
 
   /**
@@ -189,6 +188,6 @@ public class OrderController {
       @RequestParam String userId,
       Pageable pageable
   ) {
-    return ResponseEntity.ok(orderServiceForUser.viewAllOrdersDuringYears(userId, pageable));
+    return ResponseEntity.ok(orderUserService.viewAllOrdersDuringYears(userId, pageable));
   }
 }

--- a/src/main/java/com/chs/cafeapp/order/repository/OrderRepository.java
+++ b/src/main/java/com/chs/cafeapp/order/repository/OrderRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
@@ -20,4 +21,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
   Slice<Order> findAllByUserId(Pageable pageable, long userId);
   Slice<Order> findAllByUserIdAndCreateDateTimeBetween(long userId, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
 
+  @Transactional
+  void deleteAllByUpdateDateTimeLessThan(LocalDateTime nowLocalDateTimeMinusOneYears);
 }

--- a/src/main/java/com/chs/cafeapp/order/repository/OrderRepository.java
+++ b/src/main/java/com/chs/cafeapp/order/repository/OrderRepository.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
   List<Order> findAllByOrderStatus(OrderStatus orderStatus);
-
+  List<Order> findAllByUpdateDateTimeLessThan(LocalDateTime localDateTime);
   Slice<Order> findAllByCreateDateTimeBetween(LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
   Slice<Order> findAllByOrderStatus(OrderStatus orderStatus, Pageable pageable);
   Slice<Order> findAllByOrderStatusAndCreateDateTimeBetween(OrderStatus orderStatus, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);

--- a/src/main/java/com/chs/cafeapp/order/service/OrderAdminService.java
+++ b/src/main/java/com/chs/cafeapp/order/service/OrderAdminService.java
@@ -1,13 +1,10 @@
 package com.chs.cafeapp.order.service;
 
-import com.chs.cafeapp.order.dto.OrderAllFromCartInput;
 import com.chs.cafeapp.order.dto.OrderDto;
-import com.chs.cafeapp.order.dto.OrderFromCartInput;
-import com.chs.cafeapp.order.dto.OrderInput;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-public interface OrderServiceForAdmin {
+public interface OrderAdminService {
   /**
    * 주문 전체 조회
    */

--- a/src/main/java/com/chs/cafeapp/order/service/OrderUserService.java
+++ b/src/main/java/com/chs/cafeapp/order/service/OrderUserService.java
@@ -7,7 +7,7 @@ import com.chs.cafeapp.order.dto.OrderInput;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-public interface OrderServiceForUser {
+public interface OrderUserService {
   /**
    * 개별 상품 주문
    */

--- a/src/main/java/com/chs/cafeapp/order/service/impl/OrderAdminServiceImpl.java
+++ b/src/main/java/com/chs/cafeapp/order/service/impl/OrderAdminServiceImpl.java
@@ -17,7 +17,7 @@ import com.chs.cafeapp.order.dto.OrderDto;
 import com.chs.cafeapp.order.entity.Order;
 import com.chs.cafeapp.order.entity.OrderedMenu;
 import com.chs.cafeapp.order.repository.OrderRepository;
-import com.chs.cafeapp.order.service.OrderServiceForAdmin;
+import com.chs.cafeapp.order.service.OrderAdminService;
 import com.chs.cafeapp.order.service.validation.ValidationCheck;
 import com.chs.cafeapp.order.type.OrderStatus;
 import com.chs.cafeapp.stamp.service.StampService;
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class OrderServiceForAdminImpl implements OrderServiceForAdmin {
+public class OrderAdminServiceImpl implements OrderAdminService {
   private final MenuRepository menuRepository;
   private final OrderRepository orderRepository;
   private final CouponRepository couponRepository;

--- a/src/main/java/com/chs/cafeapp/order/service/impl/OrderUserServiceImpl.java
+++ b/src/main/java/com/chs/cafeapp/order/service/impl/OrderUserServiceImpl.java
@@ -25,7 +25,7 @@ import com.chs.cafeapp.order.entity.Order;
 import com.chs.cafeapp.order.entity.OrderedMenu;
 import com.chs.cafeapp.order.repository.OrderRepository;
 import com.chs.cafeapp.order.repository.OrderedMenuRepository;
-import com.chs.cafeapp.order.service.OrderServiceForUser;
+import com.chs.cafeapp.order.service.OrderUserService;
 import com.chs.cafeapp.order.service.validation.ValidationCheck;
 import com.chs.cafeapp.user.entity.User;
 import com.chs.cafeapp.user.repository.UserRepository;
@@ -43,7 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class OrderServiceForUserImpl implements OrderServiceForUser {
+public class OrderUserServiceImpl implements OrderUserService {
 
   private final MenuRepository menuRepository;
   private final UserRepository userRepository;

--- a/src/main/java/com/chs/cafeapp/scheduler/DataBaseDeleteScheduler.java
+++ b/src/main/java/com/chs/cafeapp/scheduler/DataBaseDeleteScheduler.java
@@ -59,7 +59,7 @@ public class DataBaseDeleteScheduler {
 
   // 매일 12시에 체크
   // 탈퇴한 회원 정보 수집 기간(2년 뒤 파기)
-  @Scheduled(cron = "* * * * * *", zone = SEOUL_TIME_ZONE)
+  @Scheduled(cron = "0 0 0 * * *", zone = SEOUL_TIME_ZONE)
   public void userAutoDeleteScheduling() {
     LocalDateTime nowLocalDateTime = LocalDateTime.now();
     List<User> userList = userRepository.findAllByUserStatusAndUpdateDateTimeLessThan(

--- a/src/main/java/com/chs/cafeapp/scheduler/DataBaseDeleteScheduler.java
+++ b/src/main/java/com/chs/cafeapp/scheduler/DataBaseDeleteScheduler.java
@@ -1,0 +1,50 @@
+package com.chs.cafeapp.scheduler;
+
+import static com.chs.cafeapp.user.type.UserStatus.USER_STATUS_WITHDRAW;
+
+import com.chs.cafeapp.coupon.repository.CouponRepository;
+import com.chs.cafeapp.order.repository.OrderRepository;
+import com.chs.cafeapp.user.repository.UserRepository;
+import com.chs.cafeapp.user.type.UserStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@Transactional
+@AllArgsConstructor
+public class DataBaseDeleteScheduler {
+
+  private final UserRepository userRepository;
+  private final OrderRepository orderRepository;
+  private final CouponRepository couponRepository;
+
+  // 매일 12시에 체크
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  public void orderAutoDeleteScheduling() {
+    LocalDateTime nowLocalDateTime = LocalDateTime.now();
+    log.info("[현재 날짜와 시간] -> " + nowLocalDateTime + " 지금 시간으로부터 1년이상 초과된 주문들은 삭제됩니다.");
+    orderRepository.deleteAllByUpdateDateTimeLessThan(nowLocalDateTime.minusYears(1));
+  }
+
+  // 매일 12시에 체크
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  public void couponAutoDeleteScheduling() {
+    LocalDateTime nowLocalDateTime = LocalDateTime.now();
+    log.info("[현재 날짜와 시간] -> " + nowLocalDateTime + " 지금 시간으로부터 1년이상 초과된 쿠폰들은 삭제됩니다.");
+    couponRepository.deleteAllByUpdateDateTimeLessThan(nowLocalDateTime.minusYears(1));
+  }
+
+  // 매일 12시에 체크
+  // 탈퇴한 회원 정보 수집 기간(2년 뒤 파기)
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  public void userAutoDeleteScheduling() {
+    LocalDateTime nowLocalDateTime = LocalDateTime.now();
+    log.info("[현재 날짜와 시간] -> " + nowLocalDateTime + " 지금 시간으로부터 탈퇴한지 2년이상 초과된 사용자들은 삭제됩니다.");
+    userRepository.deleteAllByUserStatusAndUpdateDateTimeLessThan(USER_STATUS_WITHDRAW, nowLocalDateTime.minusYears(2));
+  }
+}

--- a/src/main/java/com/chs/cafeapp/scheduler/DataBaseDeleteScheduler.java
+++ b/src/main/java/com/chs/cafeapp/scheduler/DataBaseDeleteScheduler.java
@@ -1,12 +1,19 @@
 package com.chs.cafeapp.scheduler;
 
+import static com.chs.cafeapp.user.type.UserStatus.USER_STATUS_STOP;
 import static com.chs.cafeapp.user.type.UserStatus.USER_STATUS_WITHDRAW;
 
+import com.chs.cafeapp.coupon.entity.Coupon;
 import com.chs.cafeapp.coupon.repository.CouponRepository;
+import com.chs.cafeapp.order.entity.Order;
 import com.chs.cafeapp.order.repository.OrderRepository;
+import com.chs.cafeapp.user.entity.DeleteUser;
+import com.chs.cafeapp.user.entity.User;
+import com.chs.cafeapp.user.repository.DeleteUserRepository;
 import com.chs.cafeapp.user.repository.UserRepository;
-import com.chs.cafeapp.user.type.UserStatus;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -22,29 +29,55 @@ public class DataBaseDeleteScheduler {
   private final UserRepository userRepository;
   private final OrderRepository orderRepository;
   private final CouponRepository couponRepository;
+  private final DeleteUserRepository deleteUserRepository;
+
+  private static final String SEOUL_TIME_ZONE = "Asia/Seoul";
 
   // 매일 12시에 체크
-  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 0 0 * * *", zone = SEOUL_TIME_ZONE)
   public void orderAutoDeleteScheduling() {
     LocalDateTime nowLocalDateTime = LocalDateTime.now();
-    log.info("[현재 날짜와 시간] -> " + nowLocalDateTime + " 지금 시간으로부터 1년이상 초과된 주문들은 삭제됩니다.");
-    orderRepository.deleteAllByUpdateDateTimeLessThan(nowLocalDateTime.minusYears(1));
+    List<Order> orderList = orderRepository.findAllByUpdateDateTimeLessThan(
+        nowLocalDateTime.minusYears(1));
+    if (orderList.size() != 0) {
+      log.info("[현재 날짜와 시간] -> {} 지금 시간으로부터 1년이상 초과된 주문들 총 {}개가 삭제되었습니다.", nowLocalDateTime, orderList.size());
+      orderRepository.deleteAllByUpdateDateTimeLessThan(nowLocalDateTime.minusYears(1));
+    }
   }
 
   // 매일 12시에 체크
-  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 0 0 * * *", zone = SEOUL_TIME_ZONE)
   public void couponAutoDeleteScheduling() {
     LocalDateTime nowLocalDateTime = LocalDateTime.now();
-    log.info("[현재 날짜와 시간] -> " + nowLocalDateTime + " 지금 시간으로부터 1년이상 초과된 쿠폰들은 삭제됩니다.");
-    couponRepository.deleteAllByUpdateDateTimeLessThan(nowLocalDateTime.minusYears(1));
+    List<Coupon> couponList = couponRepository.findAllByUpdateDateTimeLessThan(
+        nowLocalDateTime.minusYears(1));
+    if (couponList.size() != 0) {
+      log.info("[현재 날짜와 시간] -> {} 지금 시간으로부터 1년이상 초과된 쿠폰들 총 {}개가 삭제되었습니다.", nowLocalDateTime, couponList.size());
+      couponRepository.deleteAllByUpdateDateTimeLessThan(nowLocalDateTime.minusYears(1));
+    }
   }
 
   // 매일 12시에 체크
   // 탈퇴한 회원 정보 수집 기간(2년 뒤 파기)
-  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "* * * * * *", zone = SEOUL_TIME_ZONE)
   public void userAutoDeleteScheduling() {
     LocalDateTime nowLocalDateTime = LocalDateTime.now();
-    log.info("[현재 날짜와 시간] -> " + nowLocalDateTime + " 지금 시간으로부터 탈퇴한지 2년이상 초과된 사용자들은 삭제됩니다.");
-    userRepository.deleteAllByUserStatusAndUpdateDateTimeLessThan(USER_STATUS_WITHDRAW, nowLocalDateTime.minusYears(2));
+    List<User> userList = userRepository.findAllByUserStatusAndUpdateDateTimeLessThan(
+        USER_STATUS_WITHDRAW, nowLocalDateTime.minusYears(2));
+
+    if (userList.size() != 0) {
+      List<DeleteUser> deleteUserList = new ArrayList<>();
+      for (User user : userList) {
+        DeleteUser deleteUser = DeleteUser.builder()
+            .loginId(user.getLoginId())
+            .userName(user.getUserName())
+            .deleteDateTime(nowLocalDateTime)
+            .build();
+        deleteUserList.add(deleteUser);
+      }
+      userRepository.deleteAllByUserStatusAndUpdateDateTimeLessThan(USER_STATUS_WITHDRAW, nowLocalDateTime.minusYears(2));
+      deleteUserRepository.saveAll(deleteUserList);
+      log.info("[현재 날짜와 시간] -> {} 지금 시간으로부터 탈퇴한지 2년이상 초과된 사용자들 총 {}명이 삭제되었습니다.", nowLocalDateTime, deleteUserList.size());
+    }
   }
 }

--- a/src/main/java/com/chs/cafeapp/scheduler/DataBaseUpdateScheduler.java
+++ b/src/main/java/com/chs/cafeapp/scheduler/DataBaseUpdateScheduler.java
@@ -1,0 +1,23 @@
+package com.chs.cafeapp.scheduler;
+
+import com.chs.cafeapp.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class DataBaseUpdateScheduler {
+  private final UserRepository userRepository;
+
+  // 매일 12시에 체크
+  // 마지막 로그인한 상태가 1년 초과 일 경우 정지
+  @Scheduled(cron = "0 0 12 * * *", zone = "Asia/Seoul")
+  public void userAutoUpdateScheduling() {
+    LocalDateTime nowLocalDateTime = LocalDateTime.now();
+    userRepository.updateUserStatusForOldLogins(nowLocalDateTime.minusYears(1));
+  }
+}

--- a/src/main/java/com/chs/cafeapp/scheduler/DataBaseUpdateScheduler.java
+++ b/src/main/java/com/chs/cafeapp/scheduler/DataBaseUpdateScheduler.java
@@ -11,13 +11,17 @@ import org.springframework.stereotype.Component;
 @Component
 @AllArgsConstructor
 public class DataBaseUpdateScheduler {
+
   private final UserRepository userRepository;
+
+  private static final String SEOUL_TIME_ZONE = "Asia/Seoul";
 
   // 매일 12시에 체크
   // 마지막 로그인한 상태가 1년 초과 일 경우 정지
-  @Scheduled(cron = "0 0 12 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 0 0 * * *", zone = SEOUL_TIME_ZONE)
   public void userAutoUpdateScheduling() {
     LocalDateTime nowLocalDateTime = LocalDateTime.now();
+    // TODO: STOP 상태로 만들기 전에 사용자 이메일에 몇일 이내 다시 로그인하지 않으면 STOP된다고 고지하기
     userRepository.updateUserStatusForOldLogins(nowLocalDateTime.minusYears(1));
   }
 }

--- a/src/main/java/com/chs/cafeapp/user/entity/DeleteUser.java
+++ b/src/main/java/com/chs/cafeapp/user/entity/DeleteUser.java
@@ -1,0 +1,33 @@
+package com.chs.cafeapp.user.entity;
+
+
+import com.chs.cafeapp.base.BaseEntity;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteUser extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @Column(unique = true)
+  private String loginId; // 이메일
+  private String userName;
+
+  private LocalDateTime deleteDateTime;
+
+}

--- a/src/main/java/com/chs/cafeapp/user/entity/User.java
+++ b/src/main/java/com/chs/cafeapp/user/entity/User.java
@@ -5,16 +5,21 @@ import com.chs.cafeapp.cart.entity.Cart;
 import com.chs.cafeapp.cart.entity.CartMenu;
 import com.chs.cafeapp.coupon.entity.Coupon;
 import com.chs.cafeapp.stamp.entity.Stamp;
+import com.chs.cafeapp.user.type.UserStatus;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,14 +35,20 @@ public class User extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
-    @Column
+    @Column(unique = true)
     private String loginId; // 이메일
     private String password;
-
     private String userName;
+
+    @Column(unique = true)
     private String nickName;
     private String sex;
     private int age;
+
+    @Enumerated(EnumType.STRING)
+    private UserStatus userStatus; //이용 가능한상태, 정지상태
+
+    private LocalDateTime lastLoginDateTime;
 
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "user")
     @ToString.Exclude

--- a/src/main/java/com/chs/cafeapp/user/repository/DeleteUserRepository.java
+++ b/src/main/java/com/chs/cafeapp/user/repository/DeleteUserRepository.java
@@ -1,0 +1,11 @@
+package com.chs.cafeapp.user.repository;
+
+import com.chs.cafeapp.user.entity.DeleteUser;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeleteUserRepository extends JpaRepository<DeleteUser, Long> {
+
+}

--- a/src/main/java/com/chs/cafeapp/user/repository/UserRepository.java
+++ b/src/main/java/com/chs/cafeapp/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.chs.cafeapp.user.repository;
 import com.chs.cafeapp.user.entity.User;
 import com.chs.cafeapp.user.type.UserStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByLoginId(String loginId);
+
+  List<User> findAllByUserStatusAndUpdateDateTimeLessThan(UserStatus userStatus, LocalDateTime nowLocalDateTime);
 
   @Transactional
   void deleteAllByUserStatusAndUpdateDateTimeLessThan(UserStatus userStatus, LocalDateTime nowLocalDateTime);

--- a/src/main/java/com/chs/cafeapp/user/repository/UserRepository.java
+++ b/src/main/java/com/chs/cafeapp/user/repository/UserRepository.java
@@ -1,11 +1,24 @@
 package com.chs.cafeapp.user.repository;
 
 import com.chs.cafeapp.user.entity.User;
+import com.chs.cafeapp.user.type.UserStatus;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByLoginId(String loginId);
+
+  @Transactional
+  void deleteAllByUserStatusAndUpdateDateTimeLessThan(UserStatus userStatus, LocalDateTime nowLocalDateTime);
+
+  @Modifying
+  @Query("UPDATE User u SET u.userStatus = 'USER_STATUS_STOP' WHERE u.lastLoginDateTime < :cutoffDateTime")
+  void updateUserStatusForOldLogins(@Param("cutoffDateTime") LocalDateTime cutoffDateTime);
 }

--- a/src/main/java/com/chs/cafeapp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/chs/cafeapp/user/service/UserServiceImpl.java
@@ -1,4 +1,0 @@
-package com.chs.cafeapp.user.service;
-
-public class UserServiceImpl implements UserService{
-}

--- a/src/main/java/com/chs/cafeapp/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/chs/cafeapp/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,6 @@
+package com.chs.cafeapp.user.service.impl;
+
+import com.chs.cafeapp.user.service.UserService;
+
+public class UserServiceImpl implements UserService {
+}

--- a/src/main/java/com/chs/cafeapp/user/type/UserStatus.java
+++ b/src/main/java/com/chs/cafeapp/user/type/UserStatus.java
@@ -1,0 +1,31 @@
+package com.chs.cafeapp.user.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserStatus {
+
+  /**
+   * 가입 요청
+   */
+  USER_STATUS_REQ("가입 요청 중입니다."),
+
+  /**
+   * 이용 상태
+   */
+  USER_STATUS_ING("가입 완료 후 이용 중인 상태 입니다."),
+
+  /**
+   * 휴먼 상태
+   */
+  USER_STATUS_STOP("로그인 안한지 1년이 초과하여 휴먼 상태입니다."),
+
+  /**
+   * 탈퇴 상태
+   */
+  USER_STATUS_WITHDRAW("탈퇴 상태입니다.");
+
+  private final String description;
+}

--- a/src/test/java/com/chs/cafeapp/config/AppConfig.java
+++ b/src/test/java/com/chs/cafeapp/config/AppConfig.java
@@ -1,0 +1,15 @@
+package com.chs.cafeapp.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public Clock clock() {
+    // 시스템 기본 시간대로 설정된 Clock 생성
+    return Clock.systemDefaultZone();
+  }
+}

--- a/src/test/java/com/chs/cafeapp/scheduler/DataBaseDeleteSchedulerTest.java
+++ b/src/test/java/com/chs/cafeapp/scheduler/DataBaseDeleteSchedulerTest.java
@@ -1,0 +1,115 @@
+package com.chs.cafeapp.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.chs.cafeapp.coupon.entity.Coupon;
+import com.chs.cafeapp.coupon.repository.CouponRepository;
+import com.chs.cafeapp.order.entity.Order;
+import com.chs.cafeapp.order.repository.OrderRepository;
+import com.chs.cafeapp.order.type.OrderStatus;
+import com.chs.cafeapp.user.entity.User;
+import com.chs.cafeapp.user.repository.UserRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class DataBaseDeleteSchedulerTest {
+  @Autowired
+  private Clock clock;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private OrderRepository orderRepository;
+
+  @Autowired
+  private CouponRepository couponRepository;
+
+  @Autowired
+  private DataBaseDeleteScheduler dataBaseDeleteScheduler;
+
+  @Autowired
+  private EntityManager em;
+
+  @BeforeEach
+  void setUp() {
+    Instant fixedInstant = Instant.parse("2023-11-01T12:00:00Z");
+    clock.fixed(fixedInstant, ZoneOffset.UTC);
+
+    Order order = Order.builder()
+        .id(2L)
+        .orderStatus(OrderStatus.PayFail)
+        .totalPrice(4100)
+        .build();
+    em.merge(order);
+
+
+    Coupon coupon = Coupon.builder()
+        .id(2L)
+        .expiredYn(false)
+        .price(4100)
+        .build();
+
+    em.merge(coupon);
+
+    User user = User.builder()
+        .id(2L)
+        .userName("신생사용자 이름")
+        .build();
+
+    em.merge(user);
+  }
+
+  @Test
+  @DisplayName("UpdateDateTime이 1년 초과된 주문 삭제 성공")
+  void orderAutoDeleteScheduling() {
+    Instant fixedInstant = Instant.parse("2021-11-01T12:00:00Z");
+    clock.fixed(fixedInstant, ZoneOffset.UTC);
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime oneYearAgo = now.minusYears(1);
+
+    Order order1 = Order.builder()
+        .id(1L)
+        .orderStatus(OrderStatus.PayFail)
+        .totalPrice(4100)
+        .build();
+    em.merge(order1);
+
+    // 특정 시간 이전 주문 삭제 스케줄러 메서드 호출
+//    dataBaseDeleteScheduler.orderAutoDeleteScheduling();
+    em.clear();
+    // orderRepository에서 deleteAllByUpdateDateTimeLessThan 메서드가 1번 호출되는지 확인
+    List<Order> remainingOrders = orderRepository.findAll();
+    assertThat(remainingOrders).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("UpdateDateTime이 1년 초과된 쿠폰 삭제 성공")
+  void couponAutoDeleteScheduling() {
+
+  }
+
+  @Test
+  @DisplayName("UpdateDateTime이 2년 초과된 쿠폰 삭제 성공")
+  void userAutoDeleteScheduling() {
+
+  }
+}

--- a/src/test/java/com/chs/cafeapp/scheduler/DataBaseDeleteSchedulerTest.java
+++ b/src/test/java/com/chs/cafeapp/scheduler/DataBaseDeleteSchedulerTest.java
@@ -78,38 +78,39 @@ class DataBaseDeleteSchedulerTest {
     em.merge(user);
   }
 
-  @Test
-  @DisplayName("UpdateDateTime이 1년 초과된 주문 삭제 성공")
-  void orderAutoDeleteScheduling() {
-    Instant fixedInstant = Instant.parse("2021-11-01T12:00:00Z");
-    clock.fixed(fixedInstant, ZoneOffset.UTC);
-    LocalDateTime now = LocalDateTime.now();
-    LocalDateTime oneYearAgo = now.minusYears(1);
-
-    Order order1 = Order.builder()
-        .id(1L)
-        .orderStatus(OrderStatus.PayFail)
-        .totalPrice(4100)
-        .build();
-    em.merge(order1);
-
-    // 특정 시간 이전 주문 삭제 스케줄러 메서드 호출
-//    dataBaseDeleteScheduler.orderAutoDeleteScheduling();
-    em.clear();
-    // orderRepository에서 deleteAllByUpdateDateTimeLessThan 메서드가 1번 호출되는지 확인
-    List<Order> remainingOrders = orderRepository.findAll();
-    assertThat(remainingOrders).hasSize(2);
-  }
-
-  @Test
-  @DisplayName("UpdateDateTime이 1년 초과된 쿠폰 삭제 성공")
-  void couponAutoDeleteScheduling() {
-
-  }
-
-  @Test
-  @DisplayName("UpdateDateTime이 2년 초과된 쿠폰 삭제 성공")
-  void userAutoDeleteScheduling() {
-
-  }
+  // TODO: test database를 따로 h2-database로 두어 테스트 코드 진행하고 싶었으나 진행하지 못함.
+//  @Test
+//  @DisplayName("UpdateDateTime이 1년 초과된 주문 삭제 성공")
+//  void orderAutoDeleteScheduling() {
+//    Instant fixedInstant = Instant.parse("2021-11-01T12:00:00Z");
+//    clock.fixed(fixedInstant, ZoneOffset.UTC);
+//    LocalDateTime now = LocalDateTime.now();
+//    LocalDateTime oneYearAgo = now.minusYears(1);
+//
+//    Order order1 = Order.builder()
+//        .id(1L)
+//        .orderStatus(OrderStatus.PayFail)
+//        .totalPrice(4100)
+//        .build();
+//    em.merge(order1);
+//
+//    // 특정 시간 이전 주문 삭제 스케줄러 메서드 호출
+////    dataBaseDeleteScheduler.orderAutoDeleteScheduling();
+//    em.clear();
+//    // orderRepository에서 deleteAllByUpdateDateTimeLessThan 메서드가 1번 호출되는지 확인
+//    List<Order> remainingOrders = orderRepository.findAll();
+//    assertThat(remainingOrders).hasSize(2);
+//  }
+//
+//  @Test
+//  @DisplayName("UpdateDateTime이 1년 초과된 쿠폰 삭제 성공")
+//  void couponAutoDeleteScheduling() {
+//
+//  }
+//
+//  @Test
+//  @DisplayName("UpdateDateTime이 2년 초과된 쿠폰 삭제 성공")
+//  void userAutoDeleteScheduling() {
+//
+//  }
 }

--- a/src/test/java/com/chs/cafeapp/service/order/OrderAdminServiceImplTest.java
+++ b/src/test/java/com/chs/cafeapp/service/order/OrderAdminServiceImplTest.java
@@ -27,8 +27,8 @@ import com.chs.cafeapp.order.entity.Order;
 import com.chs.cafeapp.order.entity.OrderedMenu;
 import com.chs.cafeapp.order.repository.OrderRepository;
 import com.chs.cafeapp.order.repository.OrderedMenuRepository;
-import com.chs.cafeapp.order.service.impl.OrderServiceForAdminImpl;
-import com.chs.cafeapp.order.service.impl.OrderServiceForUserImpl;
+import com.chs.cafeapp.order.service.impl.OrderAdminServiceImpl;
+import com.chs.cafeapp.order.service.impl.OrderUserServiceImpl;
 import com.chs.cafeapp.order.service.validation.ValidationCheck;
 import com.chs.cafeapp.order.type.OrderStatus;
 import com.chs.cafeapp.stamp.service.impl.StampServiceImpl;
@@ -52,7 +52,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
-class OrderServiceForAdminImplTest {
+class OrderAdminServiceImplTest {
   @Mock
   private UserRepository userRepository;
   @Mock
@@ -67,10 +67,10 @@ class OrderServiceForAdminImplTest {
   private CartMenusRepository cartMenusRepository;
 
   @InjectMocks
-  private OrderServiceForAdminImpl orderServiceForAdmin;
+  private OrderAdminServiceImpl orderServiceForAdmin;
 
   @InjectMocks
-  private OrderServiceForUserImpl orderServiceForUser;
+  private OrderUserServiceImpl orderServiceForUser;
   @Mock
   private StampServiceImpl stampService;
   @Mock


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
📀 User Entity 컬럼 변경 : loginId, nickName은 unique기능 설정, UserStatus(이용 가능, 정지, 탈퇴 상태 등), 마지막 로그인 날짜시간 컬럼 추가
📀주문, 쿠폰은 어느 주문이던 간에 1년 초과 된것들은 삭제(매일 12시 정오에 삭제)
📀사용자는 탈퇴한 사용자에 한에서 2년(개인정보 수집 기간)이 초과되었을 경우 삭제(매일 12시 정오에 삭제)
📀사용자 중에 마지막으로 로그인한 상태가 1년 초과되었을 경우, Stop으로 상태 변경(update)
-> 사용자 상태를 Stop으로 상태 변경 전에 사용자의 메일로 메일 보내는 기능도 추후 추가 계획
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] MariaDB 더미데이터로 테스트 
