### PR TITLE
refactor: 주석처리, DeleteUser 상속 해제, admin_data.sql 고정

### DIFF
--- a/src/main/java/com/chs/cafeapp/CafeAppApplication.java
+++ b/src/main/java/com/chs/cafeapp/CafeAppApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 
 @EnableScheduling
@@ -16,13 +15,6 @@ public class CafeAppApplication {
 
 		SpringApplication.run(CafeAppApplication.class, args);
 
-		/**
-		 * BCryptPasswordEncoder()값으로 암호화
-		 */
-		String rawPassword = "adminPassword";
-		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-		String encodedPassword = encoder.encode(rawPassword);
-		System.out.println(encodedPassword);
 	}
 
 }

--- a/src/main/java/com/chs/cafeapp/auth/controller/AuthController.java
+++ b/src/main/java/com/chs/cafeapp/auth/controller/AuthController.java
@@ -73,12 +73,12 @@ public class AuthController {
   }
 
   /**
-   *
-   * @return
+   * 로그아웃 Controller
+   * @exception CustomException: 유효하지 않은 token값일 경우, 이미 로그아웃된 사용자일 경우 CustomException 발생
+   * @return LogOutResponse: logout한 loginId, "로그아웃 되었습니다." String 값
    */
   @PostMapping("/logout")
   public ResponseEntity<LogOutResponse> logOut(@RequestHeader("Authorization") String accessToken) {
-
     return ResponseEntity.ok(authService.logOut(accessToken));
   }
   /**

--- a/src/main/java/com/chs/cafeapp/auth/user/entity/DeleteUser.java
+++ b/src/main/java/com/chs/cafeapp/auth/user/entity/DeleteUser.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class DeleteUser extends BaseEntity {
+public class DeleteUser {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;

--- a/src/main/resources/admin_data.sql
+++ b/src/main/resources/admin_data.sql
@@ -1,2 +1,10 @@
 INSERT INTO Admin (create_date_time, update_date_time, login_id, password, authority, last_login_date_time)
-VALUES (NOW(), NOW(), 'admin@naver.com', '$2a$10$zbSM.zjevI579kuDXlTNse6dJO4TMI6ejcmMYzkmHKhEwJWfVny8S', 'ROLE_ADMIN', NOW());
+VALUES (NOW(), NOW(), 'admin1@naver.com', '$2a$10$zbSM.zjevI579kuDXlTNse6dJO4TMI6ejcmMYzkmHKhEwJWfVny8S', 'ROLE_ADMIN', NOW());
+
+INSERT INTO Admin (create_date_time, update_date_time, login_id, password, authority, last_login_date_time)
+VALUES (NOW(), NOW(), 'admin2@naver.com', '$2a$10$zbSM.zjevI579kuDXlTNse6dJO4TMI6ejcmMYzkmHKhEwJWfVny8S', 'ROLE_ADMIN', NOW());
+
+INSERT INTO Admin (create_date_time, update_date_time, login_id, password, authority, last_login_date_time)
+VALUES (NOW(), NOW(), 'admin3@naver.com', '$2a$10$zbSM.zjevI579kuDXlTNse6dJO4TMI6ejcmMYzkmHKhEwJWfVny8S', 'ROLE_ADMIN', NOW());
+
+# password 는 모두 adminPassword로 동일


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
💿 DeleteUser도 BaseEntity 상속으로 생성/수정 DateTime 자동 기록
💿 main문에 암호화 비밀번호 출력

**TO-BE**
📀 로그아웃 Controller 주석
📀 DeleteUser에서 BaseEntity 상속 해제
📀  main문에 암호화 비밀번호 출력 삭제
📀 admin_data.sql에서 admin 계정 3개 insert 고정. 초기 모든 비밀번호는 adminPassword 

*TODO*
추후 비밀번호 변경 가능 기능 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
테스트 코드 불필요