### PR TITLE
refactor: 메서드명 변경, prepareList에서 access token 가져올 때 NPE 방지

### DIFF
--- a/src/main/java/com/chs/cafeapp/auth/component/TokenPrepareList.java
+++ b/src/main/java/com/chs/cafeapp/auth/component/TokenPrepareList.java
@@ -1,5 +1,7 @@
 package com.chs.cafeapp.auth.component;
 
+import static com.chs.cafeapp.auth.token.type.ACCESS_TOKEN_TYPE.NO_ACCESS_TOKEN;
+
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.stereotype.Component;
@@ -13,7 +15,7 @@ public class TokenPrepareList {
   }
 
   public String getAccessToken(String loginId) {
-    return spareList.get(loginId);
+    return spareList.getOrDefault(loginId, NO_ACCESS_TOKEN.getToken_value());
   }
 
   public void delete(String loginId) {

--- a/src/main/java/com/chs/cafeapp/auth/service/AccessTokenValidator.java
+++ b/src/main/java/com/chs/cafeapp/auth/service/AccessTokenValidator.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class AccessTokenValidator {
   private final TokenBlackList tokenBlackList;
 
-  public boolean validateToken(String accessToken) {
+  public boolean isValidateToken(String accessToken) {
     // 토큰이 블랙리스트에 있는지 확인
     if (tokenBlackList.isBlacklisted(accessToken)) {
       return false; // 블랙리스트에 있는 토큰은 유효하지 않다고 판단

--- a/src/main/java/com/chs/cafeapp/auth/token/type/ACCESS_TOKEN_TYPE.java
+++ b/src/main/java/com/chs/cafeapp/auth/token/type/ACCESS_TOKEN_TYPE.java
@@ -1,0 +1,11 @@
+package com.chs.cafeapp.auth.token.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ACCESS_TOKEN_TYPE {
+  NO_ACCESS_TOKEN(" ");
+  private String token_value;
+}

--- a/src/main/java/com/chs/cafeapp/exception/type/ErrorCode.java
+++ b/src/main/java/com/chs/cafeapp/exception/type/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
   NOT_MATCH_USER_PASSWORD(400, "로그인 비밀번호가 틀렸습니다."),
   NOT_MATCH_ORIGIN_PASSWORD(400, "기존 비밀번호가 맞지 않습니다. 다시 확인해 주십시오."),
   NOT_VALID_REFRESH_TOKEN(400, "Refresh Token이 유효하지 않습니다."),
+  NOTING_ACCESS_TOKEN(400, "Access Token이 없습니다."),
   NOT_MATCH_REFRESH_TOKEN_USER(400, "토큰의 유저 정보가 일치하지 않습니다."),
   UN_AUTHORIZATION(401, "인증이 되지 않았습니다."),
   NOT_MATCH_AUTHORIZATION(403, "접근 권한이 올바르지 않습니다."),

--- a/src/main/java/com/chs/cafeapp/security/TokenProvider.java
+++ b/src/main/java/com/chs/cafeapp/security/TokenProvider.java
@@ -109,7 +109,7 @@ public class TokenProvider {
 
   public boolean validateToken(String token) {
 
-    if (!accessTokenValidator.validateToken(token)) {
+    if (!accessTokenValidator.isValidateToken(token)) {
       log.info("로그아웃이나 재발급으로 tokenBlackList에 있는 token입니다.");
       return false;
     }


### PR DESCRIPTION
- boolean 타입 반환 시  isValidation으로 메서드 명 변경
- 민감한 uuid를 매개변수로 갖고있다는 표시를 굳이 하지 않기
- Map에서 key에 해당되는 value가 없을 경우 NPE가 발생할 수 있는 이슈 초소화 -> getOrDefault(), enum추가 , ErrorCode 추가

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
https://github.com/HanSeulChung/CafeApp/pull/23 에 해당되는 리뷰를 토대로 리팩토링을 진행하였습니다.
📀 ErrorCode 중 비밀번호 변경시 넣어놨던 prepareList에 accessToken 값이 없을 경우 에러 추가 
📀 getOrDefault에서 없을 경우 넣을 빈 String 값을 Enum 타입으로 생성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 
